### PR TITLE
Added option to do nothing on pressing the GA button.

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -3,15 +3,15 @@
   <component name="deploymentTargetDropDown">
     <targetSelectedWithDropDown>
       <Target>
-        <type value="RUNNING_DEVICE_TARGET" />
+        <type value="QUICK_BOOT_TARGET" />
         <deviceKey>
           <Key>
-            <type value="SERIAL_NUMBER" />
-            <value value="QV71006B52" />
+            <type value="VIRTUAL_DEVICE_PATH" />
+            <value value="C:\Users\djdar\.android\avd\Galaxy_S8_API_30.avd" />
           </Key>
         </deviceKey>
       </Target>
     </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2021-02-28T14:13:44.964564200Z" />
+    <timeTargetWasSelectedWithDropDown value="2021-03-07T08:53:05.513459700Z" />
   </component>
 </project>

--- a/app/src/main/java/xyz/ivaniskandar/shouko/activity/MainActivity.kt
+++ b/app/src/main/java/xyz/ivaniskandar/shouko/activity/MainActivity.kt
@@ -42,10 +42,7 @@ import androidx.navigation.NavController
 import androidx.navigation.compose.*
 import dev.chrisbanes.accompanist.insets.*
 import xyz.ivaniskandar.shouko.R
-import xyz.ivaniskandar.shouko.feature.FlipToShush
-import xyz.ivaniskandar.shouko.feature.GAKeyOverrider
-import xyz.ivaniskandar.shouko.feature.IntentAction
-import xyz.ivaniskandar.shouko.feature.MediaKeyAction
+import xyz.ivaniskandar.shouko.feature.*
 import xyz.ivaniskandar.shouko.service.TadanoAccessibilityService
 import xyz.ivaniskandar.shouko.ui.*
 import xyz.ivaniskandar.shouko.ui.theme.ShoukoTheme
@@ -82,7 +79,10 @@ class MainActivity : AppCompatActivity() {
                                 navigationIcon = if (currentRoute != ROUTE_HOME) {
                                     {
                                         IconButton(onClick = { navController.popBackStack() }) {
-                                            Icon(imageVector = Icons.Rounded.ArrowBack, contentDescription = null)
+                                            Icon(
+                                                imageVector = Icons.Rounded.ArrowBack,
+                                                contentDescription = null
+                                            )
                                         }
                                     }
                                 } else null,
@@ -90,12 +90,20 @@ class MainActivity : AppCompatActivity() {
                                     when (currentRoute) {
                                         ROUTE_HOME -> {
                                             IconButton(onClick = { startActivity(GITHUB_REPO_INTENT) }) {
-                                                Icon(imageVector = Icons.Rounded.Info, contentDescription = null)
+                                                Icon(
+                                                    imageVector = Icons.Rounded.Info,
+                                                    contentDescription = null
+                                                )
                                             }
                                         }
                                         ROUTE_ASSISTANT_LAUNCH_SELECTION -> {
-                                            IconButton(onClick = { showAssistantActionSettings = true }) {
-                                                Icon(imageVector = Icons.Rounded.Settings, contentDescription = null)
+                                            IconButton(onClick = {
+                                                showAssistantActionSettings = true
+                                            }) {
+                                                Icon(
+                                                    imageVector = Icons.Rounded.Settings,
+                                                    contentDescription = null
+                                                )
                                             }
                                         }
                                     }
@@ -115,7 +123,10 @@ class MainActivity : AppCompatActivity() {
                                 }
                             }
                             composable(ROUTE_ASSISTANT_LAUNCH_SELECTION) {
-                                AssistantActionSelection(navController, showAssistantActionSettings) {
+                                AssistantActionSelection(
+                                    navController,
+                                    showAssistantActionSettings
+                                ) {
                                     showAssistantActionSettings = false
                                 }
                             }
@@ -178,8 +189,9 @@ class MainActivity : AppCompatActivity() {
                     enabled = TadanoAccessibilityService.isActive
                 ) {
                     if (it) {
-                        val isGrantedDndAccess = context.getSystemService(NotificationManager::class.java)!!
-                            .isNotificationPolicyAccessGranted
+                        val isGrantedDndAccess =
+                            context.getSystemService(NotificationManager::class.java)!!
+                                .isNotificationPolicyAccessGranted
                         if (!isGrantedDndAccess) {
                             Toast.makeText(
                                 context,
@@ -191,13 +203,15 @@ class MainActivity : AppCompatActivity() {
                         }
 
                         if (fullTimeFlipToShush) {
-                            val isIgnoringOptimizations = context.getSystemService(PowerManager::class.java)!!
-                                .isIgnoringBatteryOptimizations(context.packageName)
+                            val isIgnoringOptimizations =
+                                context.getSystemService(PowerManager::class.java)!!
+                                    .isIgnoringBatteryOptimizations(context.packageName)
                             if (!isIgnoringOptimizations) {
                                 @SuppressLint("BatteryLife")
-                                val i = Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
-                                    data = Uri.parse("package:${context.packageName}")
-                                }
+                                val i =
+                                    Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
+                                        data = Uri.parse("package:${context.packageName}")
+                                    }
                                 context.startActivity(i)
                                 return@SwitchPreference
                             }
@@ -238,7 +252,11 @@ class MainActivity : AppCompatActivity() {
         onSettingsDialogDismissRequest: () -> Unit
     ) {
         var selectedTabIndex by remember { mutableStateOf(0) }
-        val titles = listOf(R.string.tab_title_apps, R.string.tab_title_shortcuts, R.string.tab_title_media_key)
+        val titles = listOf(
+            R.string.tab_title_apps,
+            R.string.tab_title_shortcuts,
+            R.string.tab_title_media_key
+        )
         Column {
             TabRow(
                 selectedTabIndex = selectedTabIndex,
@@ -261,29 +279,41 @@ class MainActivity : AppCompatActivity() {
                 0 -> {
                     val appItems by viewModel.appsList.observeAsState()
                     if (appItems == null) {
-                        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.Center
+                        ) {
                             CircularProgressIndicator()
                         }
                     } else {
-                        LazyColumn(contentPadding = LocalWindowInsets.current.navigationBars.toPaddingValues()) {
-                            items(appItems!!) { item ->
-                                ApplicationRow(item = item) {
-                                    val intent = Intent().apply {
-                                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                                        component = it
+                        Column {
+                            NothingRow(onClick = {
+                                prefs.assistButtonAction = NothingAction()
+                                navController.popBackStack()
+                            })
+                            LazyColumn(contentPadding = LocalWindowInsets.current.navigationBars.toPaddingValues()) {
+                                items(appItems!!) { item ->
+                                    ApplicationRow(item = item) {
+                                        val intent = Intent().apply {
+                                            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                                            component = it
+                                        }
+                                        prefs.assistButtonAction = IntentAction(intent)
+                                        navController.popBackStack()
                                     }
-                                    prefs.assistButtonAction = IntentAction(intent)
-                                    navController.popBackStack()
                                 }
                             }
+                            Spacer(modifier = Modifier.navigationBarsPadding())
                         }
-                        Spacer(modifier = Modifier.navigationBarsPadding())
                     }
                 }
                 1 -> {
                     val appItems by viewModel.shortcutList.observeAsState()
                     if (appItems == null) {
-                        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.Center
+                        ) {
                             CircularProgressIndicator()
                         }
                     } else {
@@ -306,13 +336,19 @@ class MainActivity : AppCompatActivity() {
                                 }
                             }
                         )
-                        LazyColumn(contentPadding = LocalWindowInsets.current.navigationBars.toPaddingValues()) {
-                            items(appItems!!) { item ->
-                                ShortcutCreatorRow(item = item) {
-                                    val i = Intent(Intent.ACTION_CREATE_SHORTCUT).apply {
-                                        component = it
+                        Column {
+                            NothingRow(onClick = {
+                                prefs.assistButtonAction = NothingAction()
+                                navController.popBackStack()
+                            })
+                            LazyColumn(contentPadding = LocalWindowInsets.current.navigationBars.toPaddingValues()) {
+                                items(appItems!!) { item ->
+                                    ShortcutCreatorRow(item = item) {
+                                        val i = Intent(Intent.ACTION_CREATE_SHORTCUT).apply {
+                                            component = it
+                                        }
+                                        createShortcut.launch(i)
                                     }
-                                    createShortcut.launch(i)
                                 }
                             }
                         }

--- a/app/src/main/java/xyz/ivaniskandar/shouko/feature/FlipToShush.kt
+++ b/app/src/main/java/xyz/ivaniskandar/shouko/feature/FlipToShush.kt
@@ -44,7 +44,7 @@ class FlipToShush(
 
     private val shushOnVibrationEffect = VibrationEffect
         .createWaveform(longArrayOf(12L, 150L, 10L, 250L, 8L), intArrayOf(250, 0, 200, 0, 150), -1)
-    private val shushOffVibrationEffect = VibrationEffect.createOneShot(20, 255)
+    private val shushOffVibrationEffect = VibrationEffect.createOneShot(20,  255)
 
     private var x = .1F
     private var y = .1f

--- a/app/src/main/java/xyz/ivaniskandar/shouko/feature/GAKeyOverrider.kt
+++ b/app/src/main/java/xyz/ivaniskandar/shouko/feature/GAKeyOverrider.kt
@@ -145,6 +145,7 @@ class GAKeyOverrider(
                     is MediaKeyAction -> {
                         it.runAction(service)
                     }
+                    is NothingAction -> {}
                 }
             } else {
                 Timber.e("Failed to dispatch back action, retreat!")
@@ -173,6 +174,7 @@ class GAKeyOverrider(
                             it.runAction(service)
                             service.performGlobalAction(AccessibilityService.GLOBAL_ACTION_BACK)
                         }
+                        is NothingAction -> {}
                     }
                 } else {
                     Timber.e("Failed to dispatch back action, retreat!")
@@ -308,6 +310,28 @@ class MediaKeyAction(private val key: Key) : Action() {
     }
 }
 
+class NothingAction() : Action() {
+    override fun runAction(context: Context) {
+        // We do completely nothing.
+    }
+
+    override fun getLabel(context: Context): String {
+        return context.getString(R.string.nothing_action_label)
+    }
+
+    override fun toPlainString(): String {
+        return PLAIN_STRING_PREFIX
+    }
+
+    companion object {
+        const val PLAIN_STRING_PREFIX = "#Nothing;"
+
+        fun fromPlainString(): NothingAction {
+            return NothingAction()
+        }
+    }
+}
+
 /**
  * Base class for custom action
  */
@@ -319,6 +343,9 @@ sealed class Action {
     companion object {
         fun fromPlainString(string: String): Action? {
             return when {
+                string.startsWith(NothingAction.PLAIN_STRING_PREFIX) -> {
+                    NothingAction.fromPlainString()
+                }
                 string.startsWith(IntentAction.PLAIN_STRING_PREFIX) -> {
                     IntentAction.fromPlainString(string)
                 }

--- a/app/src/main/java/xyz/ivaniskandar/shouko/service/TadanoTileParentService.kt
+++ b/app/src/main/java/xyz/ivaniskandar/shouko/service/TadanoTileParentService.kt
@@ -72,7 +72,7 @@ class TadanoTileParentService : Service() {
             if (event?.sensor?.type == TYPE_PROXIMITY) {
                 val distance = event.values[0]
                 if (distance == 0f) {
-                    vibrator.vibrate(VibrationEffect.createOneShot(21, VibrationEffect.MAX_AMPLITUDE))
+                    vibrator.vibrate(VibrationEffect.createOneShot(21, 255))
                     switchTeaWakeLock(true)
                 } else {
                     switchTeaWakeLock(false)

--- a/app/src/main/java/xyz/ivaniskandar/shouko/ui/ItemsScreen.kt
+++ b/app/src/main/java/xyz/ivaniskandar/shouko/ui/ItemsScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import xyz.ivaniskandar.shouko.R
 import xyz.ivaniskandar.shouko.feature.MediaKeyAction
 import xyz.ivaniskandar.shouko.item.ApplicationItem
 import xyz.ivaniskandar.shouko.item.ShortcutCreatorItem
@@ -82,6 +83,32 @@ fun MediaKeyRow(key: MediaKeyAction.Key, onClick: (MediaKeyAction) -> Unit) {
         ) {
             CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.high) {
                 Text(text = stringResource(id = key.labelResId), style = MaterialTheme.typography.subtitle1)
+            }
+        }
+    }
+}
+
+@Composable
+fun NothingRow(onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .clickable(onClick = { onClick.invoke() })
+            .padding(horizontal = 12.dp, vertical = 16.dp)
+            .fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            painter = painterResource(id = R.drawable.ic_close),
+            contentDescription = null,
+            modifier = Modifier.size(36.dp),
+            tint = MaterialTheme.colors.primary
+        )
+        Spacer(modifier = Modifier.width(24.dp))
+        Column(
+            modifier = Modifier.weight(1f)
+        ) {
+            CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.high) {
+                Text(text = stringResource(id = R.string.nothing_action_label), style = MaterialTheme.typography.subtitle1)
             }
         }
     }

--- a/app/src/main/java/xyz/ivaniskandar/shouko/util/IntentUtils.kt
+++ b/app/src/main/java/xyz/ivaniskandar/shouko/util/IntentUtils.kt
@@ -38,7 +38,7 @@ fun Intent.loadLabel(context: Context): String {
         shortcutLabel
     } else {
         val ri = context.packageManager.resolveActivity(this, 0)
-        ri.loadLabel(context.packageManager).toString()
+        ri?.loadLabel(context.packageManager).toString()
     }
 }
 

--- a/app/src/main/res/drawable/ic_close.xml
+++ b/app/src/main/res/drawable/ic_close.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,6 +47,7 @@
 
     <string name="intent_action_label">Launch %s</string>
     <string name="media_key_action_label">Media key %s</string>
+    <string name="nothing_action_label">Do nothing</string>
     <string name="media_key_play">Play</string>
     <string name="media_key_pause">Pause</string>
     <string name="media_key_play_pause">Play/Pause</string>


### PR DESCRIPTION
I added a button to the activity and shortcut lists to do nothing when pressing the GA button, since I noticed it's missing. For this I created a separate action (NothingAction) and followed the same structure of handling it like the the other action types.

I'm not that well versed in Jetpack Compose, so I can imagine you might not like the way I added the button though. It's pretty much slapped on to the top of the lists now. 

Of course feel free to close this pull request without merging if you don't like the solution/know a better way of doing it.