### PR TITLE
Xperia 1 III Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ Xpand the feature set of your Xperia! <sub>and *xperience* more</sub>
 Features
 ----------
 
-- **Xperia 5 II Assistant Button Override**
+- **Assistant Button Override**
+
+  This feature is available on Xperia 5 II, Xperia 10 III, Xperia 1 III.
 
   Launches an app or a shortcut when the Assistant button is pressed. You can also disable the button completely.
 

--- a/app/src/main/java/xyz/ivaniskandar/shouko/feature/GAKeyOverrider.kt
+++ b/app/src/main/java/xyz/ivaniskandar/shouko/feature/GAKeyOverrider.kt
@@ -315,7 +315,7 @@ class GAKeyOverrider(
         private const val GA_KEY_DISABLED_GLOBAL_SETTING_KEY = "somc.game_enhancer_gab_key_disabled"
 
         // Only supports Xperia 5 II
-        val isSupported = DeviceModel.isPDX206 || DeviceModel.isPDX213
+        val isSupported = DeviceModel.isPDX206 || DeviceModel.isPDX213 || DeviceModel.isPDX215
     }
 }
 

--- a/app/src/main/java/xyz/ivaniskandar/shouko/feature/GAKeyOverrider.kt
+++ b/app/src/main/java/xyz/ivaniskandar/shouko/feature/GAKeyOverrider.kt
@@ -314,7 +314,7 @@ class GAKeyOverrider(
 
         private const val GA_KEY_DISABLED_GLOBAL_SETTING_KEY = "somc.game_enhancer_gab_key_disabled"
 
-        // Only supports Xperia 5 II
+        // Only supports Xperia 5 II, Xperia 10 III, Xperia 1 III
         val isSupported = DeviceModel.isPDX206 || DeviceModel.isPDX213 || DeviceModel.isPDX215
     }
 }

--- a/app/src/main/java/xyz/ivaniskandar/shouko/util/DeviceModel.kt
+++ b/app/src/main/java/xyz/ivaniskandar/shouko/util/DeviceModel.kt
@@ -31,4 +31,14 @@ object DeviceModel {
         "SOG04",
         "XQ-BT52"
     ).contains(Build.MODEL)
+
+    // Xperia 1 III
+    val isPDX215 = arrayOf(
+        "A101SO",
+        "SO-51B",
+        "SOG03",
+        "XQ-BC72",
+        "XQ-BC62",
+        "XQ-BC52"
+    ).contains(Build.MODEL)
 }


### PR DESCRIPTION
Closes #16 I tested shouko on my Xperia 1 III (XQ-BC62) and it's working (~[corresponding APK](https://github.com/TheNetAdmin/shouko/actions/runs/1176633885)~ [updated APK with XQ-BC52](https://github.com/TheNetAdmin/shouko/actions/runs/1186864825))

![Screenshot_20210830-134345.png](https://user-images.githubusercontent.com/18525442/131402974-23363985-892a-44b6-9c99-1de6d8395f27.png)

In #16 @andreidobrica also mentioned another Xperia 1 III model, XQ-BC52, which I added in this PR but not tested as it's different from my model (XQ-BC62).