### PR TITLE
Don't strip query params when opening links

### DIFF
--- a/app/src/main/java/xyz/ivaniskandar/shouko/activity/LinkArchiverTargetActivity.kt
+++ b/app/src/main/java/xyz/ivaniskandar/shouko/activity/LinkArchiverTargetActivity.kt
@@ -16,7 +16,7 @@ class LinkArchiverTargetActivity : ComponentActivity() {
             Intent.ACTION_SEND -> {
                 val oldLink = intent.getStringExtra(Intent.EXTRA_TEXT)
                 if (oldLink != null) {
-                    val newLink = LinkCleaner.cleanLink(this, oldLink)
+                    val newLink = LinkCleaner.resolveLink(this, oldLink)
                     if (newLink != null) {
                         openLink(newLink)
                     }

--- a/app/src/main/java/xyz/ivaniskandar/shouko/activity/LinkTargetChooserActivity.kt
+++ b/app/src/main/java/xyz/ivaniskandar/shouko/activity/LinkTargetChooserActivity.kt
@@ -85,7 +85,7 @@ class LinkTargetChooserActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val cleanedUri = LinkCleaner.cleanLink(this, intent.data.toString())?.toUri()
+        val cleanedUri = LinkCleaner.resolveLink(this, intent.data.toString())?.toUri()
         val newIntent = Intent(intent).apply {
             component = null
             data = cleanedUri
@@ -255,6 +255,7 @@ private fun Scrim(
         val alpha by animateFloatAsState(
             targetValue = if (visible) 1f else 0f,
             animationSpec = TweenSpec(),
+            label = "scrim",
         )
         val dismissModifier = if (visible) {
             Modifier


### PR DESCRIPTION
Slightly adjusts behavior introduced in #75.

I realized it's annoying when it ends up stripping query params when some sites use that for identifying items (like https://www.amiami.com/eng/detail?scode=FIGURE-175695&rank= or something), so opening the links with the chooser always failed.